### PR TITLE
First iteration of calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 db/
 static/json/drivers.json
 static/json/teams.json
+static/json/calendar.json
+.DS_Store

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/iMeisa/serserilig.meisa.xyz/internal/config"
 	"github.com/iMeisa/serserilig.meisa.xyz/internal/handlers"
-	"net/http"
 )
 
 func routes(_ *config.AppConfig) http.Handler {
@@ -21,22 +22,29 @@ func routes(_ *config.AppConfig) http.Handler {
 	mux.Get("/rules", handlers.Repo.Rules)
 	mux.Get("/staff", handlers.Repo.Staff)
 	mux.Get("/standings", handlers.Repo.Standings)
+	mux.Get("/calendar", handlers.Repo.Calendar)
 
 	// Admin routes
 	mux.Get("/edit/drivers", handlers.Repo.EditDrivers)
 	mux.Get("/edit/teams", handlers.Repo.EditTeams)
+	mux.Get("/edit/calendar", handlers.Repo.EditCalendar)
 	mux.Get("/edit", handlers.Repo.Edit)
 
 	// API routes
 	mux.Get("/api/driver", handlers.Repo.GetDriver)
 	mux.Get("/api/drivers", handlers.Repo.GetAllDrivers)
 	mux.Get("/api/teams", handlers.Repo.GetAllTeams)
+	mux.Get("/api/calendar", handlers.Repo.GetAllRaces)
 
 	mux.Get("/api/drivers/add", handlers.Repo.AddDriver)
 	mux.Get("/api/drivers/delete", handlers.Repo.DeleteDriver)
 	mux.Get("/api/drivers/update", handlers.Repo.UpdateDriver)
 
 	mux.Get("/api/teams/update", handlers.Repo.UpdateTeam)
+
+	mux.Get("/api/races/add", handlers.Repo.AddRace)
+	mux.Get("/api/races/delete", handlers.Repo.DeleteRace)
+	mux.Get("/api/races/update", handlers.Repo.UpdateRace)
 
 	// HTML static files location
 	fileServer := http.FileServer(http.Dir("./static/"))

--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -1,8 +1,9 @@
 package handlers
 
 import (
-	"github.com/iMeisa/serserilig.meisa.xyz/internal/render"
 	"net/http"
+
+	"github.com/iMeisa/serserilig.meisa.xyz/internal/render"
 )
 
 func (m *Repository) EditDrivers(w http.ResponseWriter, r *http.Request) {
@@ -15,22 +16,14 @@ func (m *Repository) EditTeams(w http.ResponseWriter, r *http.Request) {
 	templateData.GetDrivers()
 	templateData.GetTeams()
 
-	driverNames := make(map[int]string)
-	var reserveDrivers []string
-	for _, driver := range templateData.Drivers {
-		if driver.TeamID == -1 {
-			reserveDrivers = append(reserveDrivers, driver.Name)
-		}
-		driverNames[driver.ID] = driver.Name
-	}
-
-	dataMap := make(map[string]interface{})
-
-	dataMap["driver_names"] = driverNames
-	dataMap["reserve_drivers"] = reserveDrivers
-	templateData.Data = dataMap
-
 	render.Template(w, r, "editteams.page.tmpl", templateData)
+}
+
+func (m *Repository) EditCalendar(w http.ResponseWriter, r *http.Request) {
+	templateData.GetRaces()
+	templateData.GetGrandPrixes()
+
+	render.Template(w, r, "editcalendar.page.tmpl", templateData)
 }
 
 func (m *Repository) Edit(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -15,6 +15,17 @@ func (m *Repository) EditDrivers(w http.ResponseWriter, r *http.Request) {
 func (m *Repository) EditTeams(w http.ResponseWriter, r *http.Request) {
 	templateData.GetDrivers()
 	templateData.GetTeams()
+	
+	driverNames := make(map[int]string)
+	var reserveDrivers []string
+	for _, driver := range templateData.Drivers {
+		if driver.TeamID == -1 {
+			reserveDrivers = append(reserveDrivers, driver.Name)
+		}
+		driverNames[driver.ID] = driver.Name
+	}
+
+	dataMap := make(map[string]interface{})
 
 	render.Template(w, r, "editteams.page.tmpl", templateData)
 }

--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -26,6 +26,10 @@ func (m *Repository) EditTeams(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dataMap := make(map[string]interface{})
+	
+	dataMap["driver_names"] = driverNames
+	dataMap["reserve_drivers"] = reserveDrivers
+	templateData.Data = dataMap
 
 	render.Template(w, r, "editteams.page.tmpl", templateData)
 }

--- a/internal/handlers/public.go
+++ b/internal/handlers/public.go
@@ -1,9 +1,10 @@
 package handlers
 
 import (
+	"net/http"
+
 	"github.com/iMeisa/serserilig.meisa.xyz/internal/models"
 	"github.com/iMeisa/serserilig.meisa.xyz/internal/render"
-	"net/http"
 )
 
 func (m *Repository) About(w http.ResponseWriter, r *http.Request) {
@@ -75,4 +76,12 @@ func (m *Repository) Home(w http.ResponseWriter, r *http.Request) {
 	m.App.Session.Put(r.Context(), "remote_ip", remoteIP)
 
 	render.Template(w, r, "home.page.tmpl", templateData)
+}
+
+func (m *Repository) Calendar(w http.ResponseWriter, r *http.Request) {
+	// templateData.GetDrivers()
+	templateData.GetRaces()
+
+	// send the data to the template
+	render.Template(w, r, "calendar.page.tmpl", templateData)
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -28,10 +28,17 @@ type RaceResult struct {
 	DNF      bool   `json:"dnf"`
 }
 
+type GrandPrix struct {
+	ID       int    `json:"id"`
+	Country  string `json:"country"`
+	FlagName string `json:"flag-name"`
+	Circuit  string `json:"circuit"`
+}
+
 type Race struct {
-	ID       int          `json:"id"`
-	Country  string       `json:"country"`
-	FlagName string       `json:"flag-name"`
-	Circuit  string       `json:"circuit"`
-	Results  []RaceResult `json:"results"`
+	ID      int          `json:"id"`
+	Gp      GrandPrix    `json:"gp"`
+	Date    string       `json:"date"`
+	Time    string       `json:"time"`
+	Results []RaceResult `json:"results"`
 }

--- a/internal/models/templatedata.go
+++ b/internal/models/templatedata.go
@@ -4,23 +4,64 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"log"
+	"sort"
 )
 
 // TemplateData holds data sent from handlers to templates
 type TemplateData struct {
-	StringMap  map[string]string
-	IntMap     map[string]int
-	FloatMap   map[string]float32
-	Data       map[string]interface{}
-	Drivers    []Driver
-	Teams      []Team
-	CSRFToken  string
-	Flash      string // Some message
-	Warning    string
-	Error      string
+	StringMap map[string]string
+	IntMap    map[string]int
+	FloatMap  map[string]float32
+	Data      map[string]interface{}
+	Drivers   []Driver
+	Teams     []Team
+	Races     []Race
+	GPs       []GrandPrix
+	CSRFToken string
+	Flash     string // Some message
+	Warning   string
+	Error     string
 }
 
-func(data *TemplateData) GetDrivers() {
+func (data *TemplateData) GetRaces() {
+	var races []Race
+	rawFile, err := ioutil.ReadFile("./static/json/calendar.json")
+	if err != nil {
+		log.Println(err)
+	}
+
+	err = json.Unmarshal(rawFile, &races)
+	if err != nil {
+		log.Println(err)
+	}
+
+	sort.Slice(races, func(i, j int) bool {
+		return races[i].Date < races[j].Date
+	})
+
+	data.Races = races
+}
+
+func (data *TemplateData) GetGrandPrixes() {
+	var gps []GrandPrix
+	rawFile, err := ioutil.ReadFile("./static/json/gp_reference.json")
+	if err != nil {
+		log.Println(err)
+	}
+
+	err = json.Unmarshal(rawFile, &gps)
+	if err != nil {
+		log.Println(err)
+	}
+
+	sort.Slice(gps, func(i, j int) bool {
+		return gps[i].Country < gps[j].Country
+	})
+
+	data.GPs = gps
+}
+
+func (data *TemplateData) GetDrivers() {
 	var drivers []Driver
 	rawFile, err := ioutil.ReadFile("./static/json/drivers.json")
 	if err != nil {
@@ -32,16 +73,16 @@ func(data *TemplateData) GetDrivers() {
 	}
 
 	noDriver := Driver{
-		ID: -1,
-		Name: "No Driver",
+		ID:            -1,
+		Name:          "No Driver",
 		PenaltyPoints: 0,
 	}
 	drivers = append(drivers, noDriver)
-	
+
 	data.Drivers = drivers
 }
 
-func(data *TemplateData) GetTeams() {
+func (data *TemplateData) GetTeams() {
 	var teams []Team
 	rawFile, err := ioutil.ReadFile("./static/json/teams.json")
 	if err != nil {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -5,11 +5,16 @@ import "github.com/iMeisa/serserilig.meisa.xyz/internal/models"
 type DatabaseRepo interface {
 	CreateDriverTable() error
 	CreateTeamTable() error
+	CreateCalendarTable() error
 	InsertDriver(driver models.Driver) error
 	DeleteDriver(driverId string) error
 	UpdateDriver(idCol, idVal, updateCol, updateVal string) error
+	InsertRace(race models.Race) error
+	DeleteRace(raceId string) error
+	UpdateRace(id, date, time string) error
 	QueryDriver(colName, value string) (models.Driver, error)
 	QueryAllDrivers() ([]models.Driver, error)
+	QueryAllRaces() ([]models.Race, error)
 	UpdateTeam(idCol, idVal, updateCol, updateVal string) error
 	QueryAllTeams() ([]models.Team, error)
 }

--- a/static/json/gp_reference.json
+++ b/static/json/gp_reference.json
@@ -1,0 +1,146 @@
+[
+    {
+        "id":1,
+        "country": "United Arab Emirates",
+        "flag-name": "/static/images/flags/are.svg",
+        "circuit": "Yas Marina Circuit"
+    },
+    {
+        "id":2,
+        "country": "Australia",
+        "flag-name": "/static/images/flags/aus.svg",
+        "circuit": "Adelaide Street Circuit"
+    },
+    {
+        "id":3,
+        "country": "Austria",
+        "flag-name": "/static/images/flags/aut.svg",
+        "circuit": "Red Bull Ring"
+    },
+    {
+        "id":4,
+        "country": "Canada",
+        "flag-name": "/static/images/flags/can.svg",
+        "circuit": "Circuit Gilles-Villeneuve"
+    },
+    {
+        "id":5,
+        "country": "Brazil",
+        "flag-name": "/static/images/flags/bra.svg",
+        "circuit": "Autodromo José Carlos Pace"
+    },
+    {
+        "id":6,
+        "country": "Portugal",
+        "flag-name": "/static/images/flags/prt.svg",
+        "circuit": "Algarve International Circuit"
+    },
+    {
+        "id":7,
+        "country": "Italy",
+        "flag-name": "/static/images/flags/ita.svg",
+        "circuit": "Autodromo Enzo e Dino Ferrari"
+    },
+    {
+        "id":8,
+        "country": "Mexico",
+        "flag-name": "/static/images/flags/mex.svg",
+        "circuit": "Autódromo Hermanos Rodríguez"
+    },
+    {
+        "id":9,
+        "country": "Bahrain",
+        "flag-name": "/static/images/flags/bhr.svg",
+        "circuit": "Bahrain International Circuit"
+    },
+    {
+        "id":10,
+        "country": "Italy",
+        "flag-name": "/static/images/flags/ita.svg",
+        "circuit": "Autodromo Nazionale di Monza "
+    },
+    {
+        "id":11,
+        "country": "Azerbaijan",
+        "flag-name": "/static/images/flags/aze.svg",
+        "circuit": "Baku City Circuit"
+    },
+    {
+        "id":12,
+        "country": "Japan",
+        "flag-name": "/static/images/flags/jpn.svg",
+        "circuit": "Suzuka International Racing Course"
+    },
+    {
+        "id":13,
+        "country": "Spain",
+        "flag-name": "/static/images/flags/esp.svg",
+        "circuit": "Circuit de Barcelona-Catalunya"
+    },
+    {
+        "id":14,
+        "country": "Monaco",
+        "flag-name": "/static/images/flags/mco.svg",
+        "circuit": "Circuit de Monaco"
+    },
+    {
+        "id":15,
+        "country": "United Kingdom",
+        "flag-name": "/static/images/flags/gbr.svg",
+        "circuit": "Silverstone Circuit"
+    },
+    {
+        "id":16,
+        "country": "Belgium",
+        "flag-name": "/static/images/flags/bel.svg",
+        "circuit": "Circuit de Spa-Francorchamps"
+    },
+    {
+        "id":17,
+        "country": "United States",
+        "flag-name": "/static/images/flags/usa.svg",
+        "circuit": "Miami International Autodrome"
+    },
+    {
+        "id":18,
+        "country": "United States",
+        "flag-name": "/static/images/flags/usa.svg",
+        "circuit": "Circuit of the Americas"
+    },
+    {
+        "id":19,
+        "country": "France",
+        "flag-name": "/static/images/flags/fra.svg",
+        "circuit": "Circuit Paul Ricard"
+    },
+    {
+        "id":20,
+        "country": "Netherlands",
+        "flag-name": "/static/images/flags/nld.svg",
+        "circuit": "Circuit Zandvoort"
+    },
+    {
+        "id":21,
+        "country": "Hungary",
+        "flag-name": "/static/images/flags/hun.svg",
+        "circuit": "Hungaroring"
+    },
+    {
+        "id":22,
+        "country": "Saudi Arabia",
+        "flag-name": "/static/images/flags/sau.svg",
+        "circuit": "Jeddah Corniche Circuit"
+    },
+    {
+        "id":23,
+        "country": "Singapore",
+        "flag-name": "/static/images/flags/sgp.svg",
+        "circuit": "Marina Bay Street Circuit"
+    },
+    {
+        "id":24,
+        "country": "China",
+        "flag-name": "/static/images/flags/chn.svg",
+        "circuit": "Shanghai International Circuit"
+    }
+]

--- a/templates/admin.layout.tmpl
+++ b/templates/admin.layout.tmpl
@@ -42,7 +42,7 @@
                 <ul class="navbar-nav">
                     <li class="nav-item"><a class="nav-link" href="/edit/drivers" id="nav-standings">Drivers</a></li>
                     <li class="nav-item"><a class="nav-link" href="/edit/teams">Teams</a></li>
-                    <li class="nav-item"><a class="nav-link disabled" href="/edit/calendar">Calendar</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/edit/calendar">Calendar</a></li>
                     <li class="nav-item"><a class="nav-link disabled" href="#">Races</a></li>
                 </ul>
             </div>

--- a/templates/base.layout.tmpl
+++ b/templates/base.layout.tmpl
@@ -51,6 +51,7 @@
                 <ul class="navbar-nav">
                     <li class="nav-item"><a class="nav-link" href="/standings" id="nav-standings">Standings</a></li>
                     <li class="nav-item"><a class="nav-link" href="/grid" id="nav-grid">Grid</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/calendar" id="nav-grid">Calendar</a></li>
                     <li class="nav-item"><a class="nav-link disabled" href="#">Race Results (Coming Soon)</a></li>
                     <li class="nav-item"><a class="nav-link" href="/rules" id="nav-rules">Rules</a></li>
                     <li class="nav-item"><a class="nav-link" href="/staff" id="nav-staff">Staff</a></li>
@@ -79,6 +80,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
             crossorigin="anonymous"></script>
+
+
 
     <script>
         function activateNav(navId) {

--- a/templates/calendar.page.tmpl
+++ b/templates/calendar.page.tmpl
@@ -1,0 +1,33 @@
+{{template "base" .}}
+
+<!-- <head>
+    <style>
+        .horizontal-scrollable>.row {
+            overflow-x: auto;
+            white-space: nowrap;
+        }
+
+        .horizontal-scrollable>.row>.col {
+            display: inline-block;
+            float: none;
+        }
+    </style>
+</head> -->
+
+{{define "content"}}
+<div class="container">
+    <div class="row">
+        {{range $index, $race := .Races}}
+        <div class="col p-5">
+            <div class="pb-2">{{add $index 1}}.</div>
+            <div class="pb-2 text-nowrap">{{$race.Date}}</div>
+            <div class="pb-2">{{$race.Time}}</div>
+            <div class="pb-2"><img src="{{.Gp.FlagName}}" height="20px" width="30px"></div>
+            <div class="pb-2 text-wrap">{{$race.Gp.Country}}</div>
+            <div class="pb-2 text-wrap">{{$race.Gp.Circuit}}</div>
+        </div>
+        {{end}}
+    </div>
+</div>
+
+{{end}}

--- a/templates/editcalendar.page.tmpl
+++ b/templates/editcalendar.page.tmpl
@@ -1,0 +1,139 @@
+{{template "admin" .}}
+
+<!-- <head>
+    <style>
+        .horizontal-scrollable>.row {
+            overflow-x: auto;
+            white-space: nowrap;
+        }
+
+        .horizontal-scrollable>.row>.col {
+            display: inline-block;
+            float: none;
+        }
+    </style>
+
+</head> -->
+
+{{define "content"}}
+<div class="container">
+    <div class="pb-3">
+        {{range $index, $race := .Races}}
+        <div class="row w-100 py-2">
+                <div class="col-1 align-self-center">
+                    <button class="btn btn-danger" onclick="deleteRace('{{$race.ID}}')">Delete</button>
+                </div>
+                <div class="col-2 text-start align-self-center">
+                    <input class="form-control" type="date" id="date-select-{{$race.ID}}" name='from' size='9' value="{{$race.Date}}" />
+                </div>
+                <div class="col-2 text-start align-self-center">
+                    <input class="form-control" type="time" id="time-select-{{$race.ID}}" name='from' size='9' value="{{$race.Time}}" />
+                </div>
+                <div class="col-1 align-self-center">
+                    <button class="btn btn-primary" onclick="updateRace('{{$race.ID}}')">Update</button>
+                </div>
+                <div class="col-1 align-self-center"><img src="{{.Gp.FlagName}}" height="20px" width="30px"></div>
+                <div class="col-2 text-start text-wrap align-self-center">{{$race.Gp.Country}}</div>
+                <div class="col-3 text-start text-wrap align-self-center">{{$race.Gp.Circuit}}</div>
+        </div>
+        {{end}}
+    </div>
+
+    <div class="alert bg-success mt-4" id="saved-alert" hidden>Saved!</div>
+    <div class="row justify-content-between">
+        <div class="col-5 align-self-center">
+            <select class="form-control form-control" id="gp-select">
+                {{range .GPs}}
+                <option value="{{.ID}}">
+                    {{.Country}} - {{.Circuit}}
+                </option>
+                {{end}}
+            </select>
+        </div>
+        
+        <div class="col-3">
+            <input class="form-control" type="date" id="date-select" name='from' size='9' value="" />
+        </div>   
+        <div class="col-3">
+            <input class="form-control" type="time" id="time-select" name='from' size='9' value="" />
+        </div>
+        <div class="col-1 align-self-center">
+            <button type="submit" class="btn btn-primary" onclick="addRace()">Add</button>
+        </div>
+    </div>
+</div>
+{{end}}
+
+{{define "css"}}
+<style>
+    .driver-name {
+        width: 50%
+    }
+
+    .driver-points {
+        width: 25%
+    }
+
+    .driver-penalty-points {
+        width: 25%
+    }
+</style>
+{{end}}
+
+{{define "js"}}
+
+<script>
+
+    function addRace() {
+        const user_ip = '{{index .StringMap "remote_ip"}}'
+        const gp_input = document.getElementById('gp-select');
+        const date_input = document.getElementById('date-select');
+        const time_input = document.getElementById('time-select');
+        console.log(date_input.value);
+        console.log(time_input.value);
+        const url = '/api/races/add?gp_id=' + gp_input.value + '&date=' + date_input.value + '&time=' + time_input.value +  '&ip=' + user_ip;
+        fetch(url).then(function(response) {
+            // console.log(response)
+            return response;
+        }).then(function(data) {
+            // console.log(data);
+        })
+
+        document.getElementById('saved-alert').removeAttribute('hidden');
+        setTimeout(() => {location.reload()}, 1000);
+    }
+
+    function deleteRace(id) {
+        // document.getElementById('delete-success').removeAttribute('hidden')
+        const user_ip = '{{index .StringMap "remote_ip"}}'
+        const del_url = '/api/races/delete?id=' + id + '&ip=' + user_ip
+        fetch(del_url)
+            .then((response) => {
+                return response
+            }).then((data) => {
+            console.log(data)
+        })
+        setTimeout(() => {location.reload()}, 1000);
+    }
+
+    function updateRace(id) {
+        const user_ip = '{{index .StringMap "remote_ip"}}'
+        const date_input = document.getElementById('date-select-' + id);
+        const time_input = document.getElementById('time-select-' + id);
+        console.log(id);
+        console.log(date_input.value);
+        console.log(time_input.value);
+        const url = '/api/races/update?id=' + id + '&date=' + date_input.value + '&time=' + time_input.value +  '&ip=' + user_ip;
+        fetch(url).then(function(response) {
+            // console.log(response)
+            return response;
+        }).then(function(data) {
+            // console.log(data);
+        })
+
+        document.getElementById('saved-alert').removeAttribute('hidden');
+        setTimeout(() => {location.reload()}, 1000);
+    }
+</script>
+
+{{end}}


### PR DESCRIPTION
Created pages:
- /calendar (responsive)
- /edit/calendar (not small screen friendly)

Implementation summary:
- Races (templated from /static/json/gp_references.json) can be added to calendar. Same circuit can be added as many times as one wishes. 
- Time and date for each race are stored separately as text. 
- Calendar is stored in `races`-table with 4 columns: id (PK), gp_id (reference to GP from `statc/json/gp_reference.json`), date, and time
- DB is cached to /static/json/calendar.json.
- Cache is included in `.gitignore`